### PR TITLE
Add pointer style to lock and cans

### DIFF
--- a/style.css
+++ b/style.css
@@ -243,12 +243,14 @@ h1 {
   margin-left: 0.03vw;
   font-size: 1.4vw;
   text-shadow: 2.5px 3px 2.5px #D7D7D7;
+  cursor: pointer !important;
 }
 
 .fa-lock:hover,
 .fa-lock-open:hover{
   font-size: 1.8vw;
   text-shadow: 2.5px 3px 2.5px #D7D7D7;
+  cursor: pointer;
 }
 
 .fa-trash-can:active {


### PR DESCRIPTION
Includes pointer for lock and trash can. Trash can pointer is marked as important to override the grabby had on saved palette.